### PR TITLE
mask the macro definition WICED_USE_WIFI_32K_CLOCK_MCO in the file of…

### DIFF
--- a/patchs/EMW3165/platform_config.h
+++ b/patchs/EMW3165/platform_config.h
@@ -39,7 +39,7 @@ extern "C" {
 #define WICED_USE_WIFI_RESET_PIN
 
 /* */
-#define WICED_USE_WIFI_32K_CLOCK_MCO
+//#define WICED_USE_WIFI_32K_CLOCK_MCO
 
 /*  OTA */
 #define PLATFORM_HAS_OTA


### PR DESCRIPTION
mask the macro definition WICED_USE_WIFI_32K_CLOCK_MCO in the file of <patchs>/EMW3165/platform_config.h, cause that EMW3165 do not have the 32K_CLOCK_MCO function.